### PR TITLE
Updated installation requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = [
-    "ioh>=0.3.8",
-    "numpy>=1.24.2",
-    "matplotlib>=3.5.1",
-    "scipy>=1.8.0",
-    "tqdm>=4.64.1"
-]
+
+dynamic = ["dependencies"]
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-ioh
-numpy
 asttokens==2.0.5
 backcall==0.2.0
 black==22.3.0
@@ -8,14 +6,14 @@ cycler==0.11.0
 decorator==5.1.1
 executing==0.8.3
 fonttools==4.33.2
-ioh==0.3.5
+ioh==0.3.14
 ipython==8.2.0
 jedi==0.18.1
 kiwisolver==1.4.2
 matplotlib==3.5.1
 matplotlib-inline==0.1.3
 mypy-extensions==0.4.3
-numpy==1.22.3
+numpy==1.24.4
 packaging==21.3
 parso==0.8.3
 pathspec==0.9.0
@@ -37,3 +35,4 @@ tqdm==4.64.1
 traitlets==5.1.1
 typing-extensions==4.2.0
 wcwidth==0.2.5
+


### PR DESCRIPTION
The ioh version that gets installed seems to be conflicting. pyproject.toml requires ioh 0.3.8 or higher, while the requirements.txt installs ioh and ioh 0.3.5. I assume that this occasionally worked if the ioh version that was installed by default was the correct version. This did not always result in correct installation, however. I updated the requirements.